### PR TITLE
fix: User migration usando async/await e removendo entradas deletadas no down

### DIFF
--- a/db/helpers/migrationHelpers.js
+++ b/db/helpers/migrationHelpers.js
@@ -1,0 +1,25 @@
+/** @format */
+
+const getDeletedLines = async (queryInterface, table) => {
+  try {
+    return await queryInterface.sequelize.query(`SELECT * from ${table} WHERE isActive IS NULL`, {
+      type: queryInterface.sequelize.QueryTypes.SELECT
+    })
+  } catch (error) {
+    console.log('Erro na função: ', error)
+    throw error
+  }
+}
+
+const truncateDeletedLines = async (queryInterface, table) => {
+  try {
+    return await queryInterface.sequelize.query(`DELETE FROM ${table} WHERE isActive IS NULL`, {
+      type: queryInterface.sequelize.QueryTypes.DELETE
+    })
+  } catch (error) {
+    console.log('Erro na função: ', error)
+    throw error
+  }
+}
+
+module.exports = { getDeletedLines, truncateDeletedLines }


### PR DESCRIPTION
01 - Corrigi o erro que daria se dessemos o down com usuários 'soft deletados' na tabela.
02 - Aproveitei e coloquei tudo com async/await que fica mais fácil de ler.
03 - Criei um helper para as migrations com as funções que pegam/apagam os registros deletados.

Testei up/down
Testei npm run refresh
Parece estar tudo certo.