### PR TITLE
Fix: PasswordRecover migration com async await e removendo dados no down

### DIFF
--- a/db/helpers/migrationHelpers.js
+++ b/db/helpers/migrationHelpers.js
@@ -1,0 +1,25 @@
+/** @format */
+
+const getDeletedLines = async (queryInterface, table) => {
+  try {
+    return await queryInterface.sequelize.query(`SELECT * from ${table} WHERE isActive IS NULL`, {
+      type: queryInterface.sequelize.QueryTypes.SELECT
+    })
+  } catch (error) {
+    console.log('Erro na função: ', error)
+    throw error
+  }
+}
+
+const truncateDeletedLines = async (queryInterface, table) => {
+  try {
+    return await queryInterface.sequelize.query(`DELETE FROM ${table} WHERE isActive IS NULL`, {
+      type: queryInterface.sequelize.QueryTypes.DELETE
+    })
+  } catch (error) {
+    console.log('Erro na função: ', error)
+    throw error
+  }
+}
+
+module.exports = { getDeletedLines, truncateDeletedLines }

--- a/db/migrations/20200408181203-rebuild-PasswordRecover.js
+++ b/db/migrations/20200408181203-rebuild-PasswordRecover.js
@@ -2,74 +2,84 @@
 
 'use strict'
 
+const { getDeletedLines, truncateDeletedLines } = require('../helpers/migrationHelpers')
+
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
-      return Promise.all([
-        //id: ok
+  up: async (queryInterface, Sequelize) => {
+    const t = await queryInterface.sequelize.transaction()
+    try {
+      //id: ok
 
-        //user_id: ok
+      //user_id: ok
 
-        //token
-        queryInterface.removeConstraint('PasswordRecovers', 'token', { transaction: t }),
+      //token
+      await queryInterface.removeConstraint('PasswordRecovers', 'token', { transaction: t })
 
-        //createdAt ok
+      //createdAt ok
 
-        //updatedAt ok
+      //updatedAt ok
 
-        //deletedAt ok
+      //deletedAt ok
 
-        //isActive
-        queryInterface
-          .addColumn(
-            'PasswordRecovers',
-            'isActive',
-            { type: 'INT(1) GENERATED ALWAYS AS (IF(deletedAt IS NULL,  1, NULL)) VIRTUAL' },
-            { transaction: t }
-          )
-          .then(() => {
-            //uniqueKeys
-            return queryInterface.addConstraint(
-              'PasswordRecovers',
-              ['token', 'isActive'],
-              {
-                type: 'unique',
-                name: 'unique_token_isActive'
-              },
-              { transaction: t }
-            )
-          })
-      ])
-    })
+      //isActive
+      await queryInterface.addColumn(
+        'PasswordRecovers',
+        'isActive',
+        { type: 'INT(1) GENERATED ALWAYS AS (IF(deletedAt IS NULL,  1, NULL)) VIRTUAL' },
+        { transaction: t }
+      )
+
+      //uniqueKeys
+      await queryInterface.addConstraint(
+        'PasswordRecovers',
+        ['token', 'isActive'],
+        {
+          type: 'unique',
+          name: 'unique_token_isActive'
+        },
+        { transaction: t }
+      )
+    } catch (error) {
+      console.log('Erro em up: ', error)
+      t.rollback()
+      throw error
+    }
   },
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
-      return Promise.all([
-        //id: ok
+  down: async (queryInterface, Sequelize) => {
+    const t = await queryInterface.sequelize.transaction()
+    try {
+      //deletar dados da migration para evitar errors de consistencia.
+      const linesToDelete = await getDeletedLines(queryInterface, 'PasswordRecovers')
+      if (linesToDelete.length > 0) await truncateDeletedLines(queryInterface, 'PasswordRecovers')
 
-        //user_id: ok
+      //id: ok
 
-        //token
-        queryInterface.addConstraint(
-          'PasswordRecovers',
-          ['token'],
-          { type: 'unique', name: 'token' },
-          { transaction: t }
-        ),
+      //user_id: ok
 
-        //createdAt ok
+      //token
+      await queryInterface.addConstraint(
+        'PasswordRecovers',
+        ['token'],
+        { type: 'unique', name: 'token' },
+        { transaction: t }
+      )
 
-        //updatedAt ok
+      //createdAt ok
 
-        //deletedAt ok
+      //updatedAt ok
 
-        //uniqueKeys
-        queryInterface.removeConstraint('PasswordRecovers', 'unique_token_isActive', { transaction: t }).then(() => {
-          //isActive
-          return queryInterface.removeColumn('PasswordRecovers', 'isActive', { transaction: t })
-        })
-      ])
-    })
+      //deletedAt ok
+
+      //uniqueKeys
+      await queryInterface.removeConstraint('PasswordRecovers', 'unique_token_isActive', { transaction: t })
+
+      //isActive
+      await queryInterface.removeColumn('PasswordRecovers', 'isActive', { transaction: t })
+    } catch (error) {
+      console.log('Erro em down: ', error)
+      t.rollback()
+      throw error
+    }
   }
 }


### PR DESCRIPTION
01 - Corrigi o erro que daria se dessemos o down com usuários 'soft deletados' na tabela.
02 - Aproveitei e coloquei tudo com async/await que fica mais fácil de ler.
03 - Criei um helper para as migrations com as funções que pegam/apagam os registros deletados.

Testei up/down
Testei npm run refresh
Parece estar tudo certo.
**Não confundir com a outra pull request que tem o mesmo texto...**