### PR TITLE
Vacancy qtd now accepts integer values

### DIFF
--- a/app/validators/vacancy.js
+++ b/app/validators/vacancy.js
@@ -69,7 +69,7 @@ const validateQtd = (value, db, mode, item) => {
   }
 
   //value is a number
-  if (typeof value !== 'undefined' && !isNumeric(value)) {
+  if (typeof value !== 'undefined' && !(Number.isInteger(value) || isNumeric(value))) {
     return 'Deve ser um número.'
   }
 }


### PR DESCRIPTION
Added Number.isInteger to validation. Now it accepts numbers as
integeres as well as strings. Apperently MySQL doesn't care.

Agora aceitou tanto string quanto numero inteiro. Eu realmente achava que o isNumeric do **Validator** retornava true tanto pra inteiros quanto inteiros representados como string.