### PR TITLE
add subfolter config and change route files

### DIFF
--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.actions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('actionApiRoute'))
+    .route(baseFolder + app.get('actionApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, authApi.adminRequired, api.list)
 
   app
-    .route(app.get('actionApiRoute') + '/:id')
+    .route(baseFolder + app.get('actionApiRoute') + '/:id')
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 }

--- a/app/routes/assignments.js
+++ b/app/routes/assignments.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.assignments
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('assignmentApiRoute'))
+    .route(baseFolder + app.get('assignmentApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, api.list)
 
   app
-    .route(app.get('assignmentApiRoute') + '/:id')
+    .route(baseFolder + app.get('assignmentApiRoute') + '/:id')
     .get(api.read)
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -1,5 +1,11 @@
+/** @format */
+
 module.exports = app => {
   const api = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('authApiRoute')).post(api.authenticate)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
+
+  app.route(baseFolder + app.get('authApiRoute')).post(api.authenticate)
 }

--- a/app/routes/calendars.js
+++ b/app/routes/calendars.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.calendars
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('calendarApiRoute'))
+    .route(baseFolder + app.get('calendarApiRoute'))
     .get(api.list)
     .post(authApi.authenticationRequired, authApi.checkAccessLevel, api.create)
 
   app
-    .route(app.get('calendarApiRoute') + '/:id')
+    .route(baseFolder + app.get('calendarApiRoute') + '/:id')
     .put(authApi.authenticationRequired, authApi.checkAccessLevel, api.update)
     .get(api.read)
     .delete(authApi.authenticationRequired, authApi.checkAccessLevel, api.delete)

--- a/app/routes/calls.js
+++ b/app/routes/calls.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.calls
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('callApiRoute'))
+    .route(baseFolder + app.get('callApiRoute'))
     .post(authApi.authenticationRequired, authApi.checkAccessLevel, api.create)
     .get(api.list)
 
   app
-    .route(app.get('callApiRoute') + '/:id')
+    .route(baseFolder + app.get('callApiRoute') + '/:id')
     .get(api.specific)
     .put(authApi.authenticationRequired, authApi.checkAccessLevel, api.update)
     .delete(authApi.authenticationRequired, authApi.checkAccessLevel, api.delete)

--- a/app/routes/cities.js
+++ b/app/routes/cities.js
@@ -1,10 +1,14 @@
+/** @format */
+
 module.exports = app => {
-  const api = app.api.cities;
-  const authApi = app.api.auth;
+  const api = app.api.cities
+  const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('cityApiRoute')+"/:state/state")
-    .get(authApi.authenticationRequired, api.list);
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
-  app.route(app.get('cityApiRoute')+"/:id")
-    .get(authApi.authenticationRequired, api.specific);
+  app.route(baseFolder + app.get('cityApiRoute') + '/:state/state').get(authApi.authenticationRequired, api.list)
+
+  app.route(baseFolder + app.get('cityApiRoute') + '/:id').get(authApi.authenticationRequired, api.specific)
 }

--- a/app/routes/courses.js
+++ b/app/routes/courses.js
@@ -3,16 +3,20 @@
 module.exports = app => {
   const api = app.api.courses
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('courseApiRoute'))
+    .route(baseFolder + app.get('courseApiRoute'))
     .post(authApi.authenticationRequired, authApi.globalPermissionRequired, api.create)
     .get(authApi.authenticationRequired, api.list)
 
-  app.route(app.get('courseApiRoute') + '/find').get(api.find)
+  app.route(baseFolder + app.get('courseApiRoute') + '/find').get(api.find)
 
   app
-    .route(app.get('courseApiRoute') + '/:id')
+    .route(baseFolder + app.get('courseApiRoute') + '/:id')
     .put(authApi.authenticationRequired, authApi.globalPermissionRequired, api.update)
     .get(authApi.authenticationRequired, api.specific)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/graduationTypes.js
+++ b/app/routes/graduationTypes.js
@@ -1,14 +1,21 @@
+/** @format */
+
 module.exports = app => {
-  const api = app.api.graduationTypes;
-  const authApi = app.api.auth;
+  const api = app.api.graduationTypes
+  const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('graduationTypeApiRoute'))
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
+
+  app
+    .route(baseFolder + app.get('graduationTypeApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
-    .get(authApi.authenticationRequired, authApi.adminRequired, api.list);
+    .get(authApi.authenticationRequired, authApi.adminRequired, api.list)
 
-  app.route(app.get('graduationTypeApiRoute')+ "/:id")
-    .get(authApi.authenticationRequired, api.specific)    
+  app
+    .route(baseFolder + app.get('graduationTypeApiRoute') + '/:id')
+    .get(authApi.authenticationRequired, api.specific)
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 }
-

--- a/app/routes/inscriptionEvents.js
+++ b/app/routes/inscriptionEvents.js
@@ -3,11 +3,18 @@
 module.exports = app => {
   const api = app.api.inscriptionEvents
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('inscriptionEventApiRoute')).post(authApi.authenticationRequired, api.create).get(api.list)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('inscriptionEventApiRoute') + '/:id')
+    .route(baseFolder + app.get('inscriptionEventApiRoute'))
+    .post(authApi.authenticationRequired, api.create)
+    .get(api.list)
+
+  app
+    .route(baseFolder + app.get('inscriptionEventApiRoute') + '/:id')
     .put(authApi.authenticationRequired, api.update)
     .get(api.read)
     .delete(authApi.authenticationRequired, api.delete)

--- a/app/routes/inscriptions.js
+++ b/app/routes/inscriptions.js
@@ -3,11 +3,18 @@
 module.exports = app => {
   const api = app.api.inscriptions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('inscriptionApiRoute')).post(authApi.authenticationRequired, api.create).get(api.list)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('inscriptionApiRoute') + '/:id')
+    .route(baseFolder + app.get('inscriptionApiRoute'))
+    .post(authApi.authenticationRequired, api.create)
+    .get(api.list)
+
+  app
+    .route(baseFolder + app.get('inscriptionApiRoute') + '/:id')
     .get(authApi.authenticationRequired, api.read)
     .delete(authApi.authenticationRequired, api.delete)
 }

--- a/app/routes/me.js
+++ b/app/routes/me.js
@@ -1,8 +1,15 @@
-module.exports = app => {
-  const api = app.api.me;
-  const authApi = app.api.auth;
+/** @format */
 
-  app.route(app.get('meApiRoute'))
+module.exports = app => {
+  const api = app.api.me
+  const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
+
+  app
+    .route(baseFolder + app.get('meApiRoute'))
     .get(authApi.authenticationRequired, api.me)
-    .put(authApi.authenticationRequired, api.update);
+    .put(authApi.authenticationRequired, api.update)
 }

--- a/app/routes/passwordrecover.js
+++ b/app/routes/passwordrecover.js
@@ -1,5 +1,11 @@
+/** @format */
+
 module.exports = app => {
   const api = app.api.passwordrecover
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   //post login to recover pass. Send a token to user via email. Return status message
   app.route(`${app.get('recoverApiRoute')}`).post(api.recoverRequire)

--- a/app/routes/people.js
+++ b/app/routes/people.js
@@ -3,13 +3,19 @@
 module.exports = app => {
   const api = app.api.people
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('personApiRoute')).post(authApi.authenticationRequired, authApi.adminRequired, api.create)
-
-  app.route(app.get('personApiRoute') + '/options').get(authApi.authenticationRequired, api.options)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('personApiRoute') + '/:id')
+    .route(baseFolder + app.get('personApiRoute'))
+    .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
+
+  app.route(baseFolder + app.get('personApiRoute') + '/options').get(authApi.authenticationRequired, api.options)
+
+  app
+    .route(baseFolder + app.get('personApiRoute') + '/:id')
     .get(authApi.authenticationRequired, api.read)
     .put(authApi.authenticationRequired, authApi.checkAccessLevel, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/permissions.js
+++ b/app/routes/permissions.js
@@ -3,13 +3,17 @@
 module.exports = app => {
   const api = app.api.permissions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('permissionApiRoute'))
+    .route(baseFolder + app.get('permissionApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, authApi.adminRequired, api.list)
 
   app
-    .route(app.get('permissionApiRoute') + '/:id')
+    .route(baseFolder + app.get('permissionApiRoute') + '/:id')
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 }

--- a/app/routes/petitionEvents.js
+++ b/app/routes/petitionEvents.js
@@ -3,11 +3,18 @@
 module.exports = app => {
   const api = app.api.petitionEvents
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('petitionEventApiRoute')).post(authApi.authenticationRequired, api.create).get(api.list)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('petitionEventApiRoute') + '/:id')
+    .route(baseFolder + app.get('petitionEventApiRoute'))
+    .post(authApi.authenticationRequired, api.create)
+    .get(api.list)
+
+  app
+    .route(baseFolder + app.get('petitionEventApiRoute') + '/:id')
     .put(authApi.authenticationRequired, api.update)
     .get(api.read)
     .delete(authApi.authenticationRequired, api.delete)

--- a/app/routes/petitionReplies.js
+++ b/app/routes/petitionReplies.js
@@ -3,13 +3,17 @@
 module.exports = app => {
   const api = app.api.petitionReplies
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('petitionReplyApiRoute'))
+    .route(baseFolder + app.get('petitionReplyApiRoute'))
     .post(authApi.authenticationRequired, api.create)
     .get(authApi.authenticationRequired, api.list)
 
-  app.route(app.get('petitionReplyApiRoute') + '/:id').get(authApi.authenticationRequired, api.read)
+  app.route(baseFolder + app.get('petitionReplyApiRoute') + '/:id').get(authApi.authenticationRequired, api.read)
   //.put(authApi.authenticationRequired, api.update)
   //.delete(authApi.authenticationRequired, api.delete)
 }

--- a/app/routes/petitions.js
+++ b/app/routes/petitions.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.petitions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('petitionApiRoute'))
+    .route(baseFolder + app.get('petitionApiRoute'))
     .post(authApi.authenticationRequired, api.create)
     .get(authApi.authenticationRequired, api.list)
 
   app
-    .route(app.get('petitionApiRoute') + '/:id')
+    .route(baseFolder + app.get('petitionApiRoute') + '/:id')
     .get(authApi.authenticationRequired, api.read)
     .delete(authApi.authenticationRequired, api.delete)
 }

--- a/app/routes/publicationTypes.js
+++ b/app/routes/publicationTypes.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.publicationTypes
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('publicationTypeApiRoute'))
+    .route(baseFolder + app.get('publicationTypeApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, api.list)
 
   app
-    .route(app.get('publicationTypeApiRoute') + '/:id')
+    .route(baseFolder + app.get('publicationTypeApiRoute') + '/:id')
     .get(authApi.authenticationRequired, api.specific)
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/publications.js
+++ b/app/routes/publications.js
@@ -4,9 +4,13 @@ module.exports = app => {
   const api = app.api.publications
   const fileUpload = app.helpers.fileUpload
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('publicationApiRoute'))
+    .route(baseFolder + app.get('publicationApiRoute'))
     .post(
       authApi.authenticationRequired,
       authApi.checkAccessLevel,
@@ -16,10 +20,10 @@ module.exports = app => {
     )
 
   app
-    .route(app.get('publicationApiRoute') + '/:id')
+    .route(baseFolder + app.get('publicationApiRoute') + '/:id')
     .get(authApi.authenticationRequired, authApi.checkAccessLevel, api.specific)
     .put(authApi.authenticationRequired, authApi.checkAccessLevel, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 
-  app.route(app.get('publicationApiRoute') + '/download/:file').get(api.download)
+  app.route(baseFolder + app.get('publicationApiRoute') + '/download/:file').get(api.download)
 }

--- a/app/routes/regions.js
+++ b/app/routes/regions.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.regions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('regionApiRoute'))
+    .route(baseFolder + app.get('regionApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(api.list)
 
   app
-    .route(app.get('regionApiRoute') + '/:id')
+    .route(baseFolder + app.get('regionApiRoute') + '/:id')
     .get(api.read)
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/register.js
+++ b/app/routes/register.js
@@ -2,6 +2,10 @@
 
 module.exports = app => {
   const api = app.api.register
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('register')).post(api.createV2)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
+
+  app.route(baseFolder + app.get('register')).post(api.createV2)
 }

--- a/app/routes/restrictions.js
+++ b/app/routes/restrictions.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.restrictions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('restrictionApiRoute'))
+    .route(baseFolder + app.get('restrictionApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(api.list)
 
   app
-    .route(app.get('restrictionApiRoute') + '/:id')
+    .route(baseFolder + app.get('restrictionApiRoute') + '/:id')
     .get(api.read)
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/rolePermissions.js
+++ b/app/routes/rolePermissions.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.rolePermissions
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('rolePermissionApiRoute'))
+    .route(baseFolder + app.get('rolePermissionApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, authApi.adminRequired, api.list)
 
   app
-    .route(app.get('rolePermissionApiRoute') + '/:id')
+    .route(baseFolder + app.get('rolePermissionApiRoute') + '/:id')
     .get(authApi.authenticationRequired, authApi.adminRequired, api.read)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 }

--- a/app/routes/roleTypes.js
+++ b/app/routes/roleTypes.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.roleTypes
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('roleTypeApiRoute'))
+    .route(baseFolder + app.get('roleTypeApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, api.list)
 
   app
-    .route(app.get('roleTypeApiRoute') + '/:id')
+    .route(baseFolder + app.get('roleTypeApiRoute') + '/:id')
     .get(authApi.authenticationRequired, api.read)
     .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/selectiveProcesses.js
+++ b/app/routes/selectiveProcesses.js
@@ -3,16 +3,20 @@
 module.exports = app => {
   const api = app.api.selectiveProcesses
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('selectiveProcessApiRoute'))
+    .route(baseFolder + app.get('selectiveProcessApiRoute'))
     .post(authApi.authenticationRequired, authApi.checkAccessLevel, api.create)
     .get(api.listPublic, authApi.authenticationRequired, api.list)
 
-  app.route(app.get('selectiveProcessApiRoute') + '/filters').get(api.filters)
+  app.route(baseFolder + app.get('selectiveProcessApiRoute') + '/filters').get(api.filters)
 
   app
-    .route(app.get('selectiveProcessApiRoute') + '/:id')
+    .route(baseFolder + app.get('selectiveProcessApiRoute') + '/:id')
     .get(api.specificPublic, authApi.authenticationRequired, api.specific)
     .put(authApi.authenticationRequired, authApi.checkAccessLevel, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/states.js
+++ b/app/routes/states.js
@@ -1,10 +1,14 @@
+/** @format */
+
 module.exports = app => {
-  const api = app.api.states;
-  const authApi = app.api.auth;
+  const api = app.api.states
+  const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('stateApiRoute'))
-    .get(authApi.authenticationRequired, api.list);
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
-  app.route(app.get('stateApiRoute')+"/:data")
-    .get(authApi.authenticationRequired, api.specific);
+  app.route(baseFolder + app.get('stateApiRoute')).get(authApi.authenticationRequired, api.list)
+
+  app.route(baseFolder + app.get('stateApiRoute') + '/:data').get(authApi.authenticationRequired, api.specific)
 }

--- a/app/routes/stepTypes.js
+++ b/app/routes/stepTypes.js
@@ -1,13 +1,20 @@
-module.exports = app => {
-    const api = app.api.stepTypes;
-    const authApi = app.api.auth;
+/** @format */
 
-    app.route(app.get('stepTypeApiRoute'))
-        .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
-        .get(authApi.authenticationRequired, api.list)
-    
-    app.route(app.get('stepTypeApiRoute')+"/:id")
-        .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
-        .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
+module.exports = app => {
+  const api = app.api.stepTypes
+  const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
+
+  app
+    .route(baseFolder + app.get('stepTypeApiRoute'))
+    .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
+    .get(authApi.authenticationRequired, api.list)
+
+  app
+    .route(baseFolder + app.get('stepTypeApiRoute') + '/:id')
+    .put(authApi.authenticationRequired, authApi.adminRequired, api.update)
+    .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 }
-  

--- a/app/routes/steps.js
+++ b/app/routes/steps.js
@@ -3,11 +3,17 @@
 module.exports = app => {
   const api = app.api.steps
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('stepApiRoute')).post(authApi.authenticationRequired, authApi.checkAccessLevel, api.create)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('stepApiRoute') + '/:id')
+    .route(baseFolder + app.get('stepApiRoute'))
+    .post(authApi.authenticationRequired, authApi.checkAccessLevel, api.create)
+
+  app
+    .route(baseFolder + app.get('stepApiRoute') + '/:id')
     .get(authApi.authenticationRequired, api.specific)
     .put(authApi.authenticationRequired, authApi.checkAccessLevel, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/targets.js
+++ b/app/routes/targets.js
@@ -3,13 +3,17 @@
 module.exports = app => {
   const api = app.api.targets
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('targetApiRoute'))
+    .route(baseFolder + app.get('targetApiRoute'))
     .post(authApi.authenticationRequired, authApi.adminRequired, api.create)
     .get(authApi.authenticationRequired, authApi.adminRequired, api.list)
 
   app
-    .route(app.get('targetApiRoute') + '/:id')
+    .route(baseFolder + app.get('targetApiRoute') + '/:id')
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)
 }

--- a/app/routes/userRoles.js
+++ b/app/routes/userRoles.js
@@ -3,14 +3,18 @@
 module.exports = app => {
   const api = app.api.userRoles
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('userRoleApiRoute'))
+    .route(baseFolder + app.get('userRoleApiRoute'))
     .post(authApi.authenticationRequired, authApi.globalPermissionRequired, api.create)
     .get(authApi.authenticationRequired, authApi.globalPermissionRequired, api.list)
 
   app
-    .route(app.get('userRoleApiRoute') + '/:id')
+    .route(baseFolder + app.get('userRoleApiRoute') + '/:id')
     .delete(authApi.authenticationRequired, authApi.globalPermissionRequired, api.delete)
     .get(authApi.authenticationRequired, authApi.globalPermissionRequired, api.specific)
 }

--- a/app/routes/userVerificationToken.js
+++ b/app/routes/userVerificationToken.js
@@ -3,8 +3,14 @@
 module.exports = app => {
   const api = app.api.userVerificationTokens
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('userVerificationTokenApiRoute') + '/send').get(authApi.authenticationRequired, api.send)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
-  app.route(app.get('userVerificationTokenApiRoute') + '/:token').get(api.verify)
+  app
+    .route(baseFolder + app.get('userVerificationTokenApiRoute') + '/send')
+    .get(authApi.authenticationRequired, api.send)
+
+  app.route(baseFolder + app.get('userVerificationTokenApiRoute') + '/:token').get(api.verify)
 }

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -3,18 +3,22 @@
 module.exports = app => {
   const api = app.api.users
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
+
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('userApiRoute'))
+    .route(baseFolder + app.get('userApiRoute'))
     .post(authApi.authenticationRequired, authApi.globalPermissionRequired, api.create)
     .get(authApi.authenticationRequired, authApi.globalPermissionRequired, api.list)
 
   app
-    .route(app.get('userApiRoute') + '/minimal')
+    .route(baseFolder + app.get('userApiRoute') + '/minimal')
     .get(authApi.authenticationRequired, authApi.globalPermissionRequired, api.minimal)
 
   app
-    .route(app.get('userApiRoute') + '/:id')
+    .route(baseFolder + app.get('userApiRoute') + '/:id')
     .get(authApi.authenticationRequired, authApi.globalPermissionRequired, api.specific)
     .put(authApi.authenticationRequired, authApi.globalPermissionRequired, api.update)
     .delete(authApi.authenticationRequired, authApi.adminRequired, api.delete)

--- a/app/routes/vacancies.js
+++ b/app/routes/vacancies.js
@@ -3,11 +3,18 @@
 module.exports = app => {
   const api = app.api.vacancies
   const authApi = app.api.auth
+  const siteConf = require('../../config/site')
 
-  app.route(app.get('vacancyApiRoute')).post(authApi.authenticationRequired, api.create).get(api.list)
+  //create base folder
+  const baseFolder = siteConf.backend_base_subfolder ? siteConf.backend_base_subfolder : ''
 
   app
-    .route(app.get('vacancyApiRoute') + '/:id')
+    .route(baseFolder + app.get('vacancyApiRoute'))
+    .post(authApi.authenticationRequired, api.create)
+    .get(api.list)
+
+  app
+    .route(baseFolder + app.get('vacancyApiRoute') + '/:id')
     .put(authApi.authenticationRequired, api.update)
     .get(api.read)
     .delete(authApi.authenticationRequired, api.delete)

--- a/config/_example.site.js
+++ b/config/_example.site.js
@@ -3,6 +3,7 @@
 module.exports = {
   //backend data
   backend_url: 'http://localhost:3000',
+  backend_base_subfolder: '',
   port: 3000,
 
   //prime frontend data


### PR DESCRIPTION
To simplify server configurations (firewall config, https configs, nginx configs)
Now we can configure a base subfolder to the api.
With this, we can now serve the api on a subfolder without extensive configurations.